### PR TITLE
Fix Py <= 3.9 compatibility + style tweaks

### DIFF
--- a/doc/make.py
+++ b/doc/make.py
@@ -1,7 +1,6 @@
 """
 Build script for documentation
 """
-from glob import glob
 import os
 from shutil import which, rmtree
 import subprocess

--- a/doc/make.py
+++ b/doc/make.py
@@ -8,11 +8,14 @@ import subprocess
 from pathlib import Path
 from typing import Union, List
 
+
+# General sphinx state / options
 SPHINXOPTS      = []
 SPHINXBUILD     = "sphinx-build"
 SPHINXAUTOBUILD = "sphinx-autobuild"
 PAPER           = None
 BUILDDIR        = "build"
+
 
 # Internal variables.
 PAPEROPTS = {}
@@ -21,10 +24,15 @@ PAPEROPTS['a4'] = ['-D', 'latex_paper_size=a4']
 PAPEROPTS['letter'] = ['-D', 'latex_paper_size=letter']
 ALLSPHINXOPTS       = ['-d', f'{BUILDDIR}/doctrees', *PAPEROPTS[PAPER], *SPHINXOPTS, '.']
 SPHINXAUTOBUILDOPTS = ['--watch', '../arcade']
-# the i18n builder cannot share the environment and doctrees with the others
+
+# Important: the i18n builder cannot share the environment and doctrees with the others
+# This allows for internationalization / localization of doc.
 I18NSPHINXOPTS      = [*PAPEROPTS[PAPER], *SPHINXOPTS, '.']
 
+
+# Change dirs into root arcade project folder
 os.chdir(Path(__file__).parent.resolve())
+
 
 # User-friendly check for dependencies and binaries
 binaries = ['sphinx-build', 'sphinx-autobuild']
@@ -46,7 +54,6 @@ for library in libraries:
         print("Python dependencies not found: " + ', '.join(not_found))
         print("Did you forget to install them with `pip`?  See CONTRIBUTING.md file for instructions.")
         exit(1)
-    
 
 
 import typer
@@ -328,6 +335,7 @@ def pseudoxml():
     run([SPHINXBUILD, "-b", "pseudoxml", *ALLSPHINXOPTS, f"{BUILDDIR}/pseudoxml"])
     print()
     print("Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml.")
+
 
 if __name__ == "__main__":
     app()

--- a/doc/make.py
+++ b/doc/make.py
@@ -6,6 +6,7 @@ import os
 from shutil import which, rmtree
 import subprocess
 from pathlib import Path
+from typing import Union, List
 
 SPHINXOPTS      = []
 SPHINXBUILD     = "sphinx-build"
@@ -51,10 +52,12 @@ for library in libraries:
 import typer
 app = typer.Typer()
 
-def run(args: str | list[str]):
+
+def run(args: Union[str, List[str]]) -> None:
     result = subprocess.run(args)
     if result.returncode != 0:
         exit(result.returncode)
+
 
 @app.command()
 def clean():

--- a/doc/make.py
+++ b/doc/make.py
@@ -12,21 +12,21 @@ from typing import Union, List
 SPHINXOPTS      = []
 SPHINXBUILD     = "sphinx-build"
 SPHINXAUTOBUILD = "sphinx-autobuild"
-PAPER           = None
+PAPER_SIZE      = None
 BUILDDIR        = "build"
 
 
 # Internal variables.
-PAPEROPTS = {}
-PAPEROPTS[None] = []
-PAPEROPTS['a4'] = ['-D', 'latex_paper_size=a4']
-PAPEROPTS['letter'] = ['-D', 'latex_paper_size=letter']
-ALLSPHINXOPTS       = ['-d', f'{BUILDDIR}/doctrees', *PAPEROPTS[PAPER], *SPHINXOPTS, '.']
+PAPER_SIZE_OPTS = {}
+PAPER_SIZE_OPTS[None] = []
+PAPER_SIZE_OPTS['a4'] = ['-D', 'latex_paper_size=a4']
+PAPER_SIZE_OPTS['letter'] = ['-D', 'latex_paper_size=letter']
+ALLSPHINXOPTS       = ['-d', f'{BUILDDIR}/doctrees', *PAPER_SIZE_OPTS[PAPER_SIZE], *SPHINXOPTS, '.']
 SPHINXAUTOBUILDOPTS = ['--watch', '../arcade']
 
 # Important: the i18n builder cannot share the environment and doctrees with the others
 # This allows for internationalization / localization of doc.
-I18NSPHINXOPTS      = [*PAPEROPTS[PAPER], *SPHINXOPTS, '.']
+I18NSPHINXOPTS      = [*PAPER_SIZE_OPTS[PAPER_SIZE], *SPHINXOPTS, '.']
 
 
 # Change dirs into root arcade project folder
@@ -197,7 +197,7 @@ def epub():
 @app.command()
 def latex():
     """
-    to make LaTeX files, you can set PAPER=a4 or PAPER=letter
+    to make LaTeX files, you can set PAPER_SIZE=a4 or PAPER_SIZE=letter
     """
     run([SPHINXBUILD, "-b", "latex", *ALLSPHINXOPTS, f"{BUILDDIR}/latex"])
     print()


### PR DESCRIPTION
Fixes the following:
```console
$ python ./make.py serve
Traceback (most recent call last):
  File "/home/user/src/arcade/doc/./make.py", line 54, in <module>
    def run(args: str | list[str]):
TypeError: unsupported operand type(s) for |: 'type' and 'types.GenericAlias'
```